### PR TITLE
Make it compatible with jQuery’s noConflict mode

### DIFF
--- a/src/vue-froala.js
+++ b/src/vue-froala.js
@@ -92,7 +92,7 @@ export default (Vue, Options = {}) => {
 
         this.currentConfig = this.config || this.defaultConfig;
 
-        this._$element = $(this.$el);
+        this._$element = jQuery(this.$el);
 
         this.setContent(true);
 


### PR DESCRIPTION
If using jQuery with noConflict mode (see https://api.jquery.com/jquery.noconflict/ ), this library can't be used. 
Luckily, this is very easy to fix. There is just one place that has to use `jQuery` instead of the short alias `$`.