### PR TITLE
Changed component names to Pascal

### DIFF
--- a/src/vue-froala.js
+++ b/src/vue-froala.js
@@ -271,7 +271,7 @@ export default (Vue, Options = {}) => {
     }    
   };
 
-  Vue.component('froala', froalaEditorFunctionality);
+  Vue.component('Froala', froalaEditorFunctionality);
 
   var froalaViewFunctionality = {
 
@@ -314,5 +314,5 @@ export default (Vue, Options = {}) => {
     }
   };
 
-  Vue.component('froalaView', froalaViewFunctionality);
+  Vue.component('FroalaView', froalaViewFunctionality);
 }


### PR DESCRIPTION
According to _Component name casing_ section in VueJS style guide, recommendation:
> component names should always be PascalCase in single-file components and string templates

https://vuejs.org/v2/style-guide/#Component-name-casing-in-templates-strongly-recommended

This PR not contains breaking changes, because if component registered in _PascalCase_, we can use both approaches - _kebab-case_ and _PascalCase_.

https://vuejs.org/v2/guide/components-registration.html#Name-Casing