### PR TITLE
fix: htmlSet error in modal

### DIFF
--- a/src/vue-froala.js
+++ b/src/vue-froala.js
@@ -165,9 +165,9 @@ export default (Vue, Options = {}) => {
       },
 
       destroyEditor: function() {
+        this.initEvents = [];
 
         if (this._editor) {
-
           this._editor.destroy();
           this.editorInitialized = false;
           this._editor = null;


### PR DESCRIPTION
For more details: #107 
Maybe also related to #87 but didn't check with v-if

Also there is one more PR open maybe for the same thing I am trying to do (but I did go with small change), also look at that: #98.

## My error case
Error was coming for recreating editor because in initEvents it keeps reference of old VueComponent and that even again calls again the new instance is created but it gets _editor null because we destroyed it.

>Also it can create memory leak problems because it was keeping VueComponent in init event callback.
